### PR TITLE
Seperate the world plugins from being loaded with the map (along with the humans)

### DIFF
--- a/flatland_plugins/test/bumper_test.cpp
+++ b/flatland_plugins/test/bumper_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_msgs;
 class BumperPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   flatland_msgs::Collisions msg1, msg2;
   World* w;
 
@@ -182,12 +182,13 @@ class BumperPluginTest : public ::testing::Test {
  * Test the bumper plugin for a given model and plugin configuration
  */
 TEST_F(BumperPluginTest, collision_test) {
-  world_yaml =
-      this_file_dir / fs::path("bumper_tests/collision_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("bumper_tests/collision_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.01);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -284,10 +285,12 @@ TEST_F(BumperPluginTest, collision_test) {
  * Test with a invalid body specified in the exclude list
  */
 TEST_F(BumperPluginTest, invalid_A) {
-  world_yaml = this_file_dir / fs::path("bumper_tests/invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("bumper_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
     std::cmatch match;

--- a/flatland_plugins/test/bumper_tests/collision_test/world.yaml
+++ b/flatland_plugins/test/bumper_tests/collision_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/bumper_tests/collision_test/world_plugins.yaml
+++ b/flatland_plugins/test/bumper_tests/collision_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/bumper_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/bumper_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../collision_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/bumper_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/bumper_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_test.cpp
+++ b/flatland_plugins/test/laser_test.cpp
@@ -60,7 +60,7 @@ using namespace flatland_plugins;
 class LaserPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   sensor_msgs::LaserScan scan_front, scan_center, scan_back;
   World* w;
 
@@ -166,11 +166,13 @@ class LaserPluginTest : public ::testing::Test {
  * Test the laser plugin for a given model and plugin configuration
  */
 TEST_F(LaserPluginTest, range_test) {
-  world_yaml = this_file_dir / fs::path("laser_tests/range_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/range_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -212,12 +214,13 @@ TEST_F(LaserPluginTest, range_test) {
  * Test the laser plugin for intensity configuration
  */
 TEST_F(LaserPluginTest, intensity_test) {
-  world_yaml =
-      this_file_dir / fs::path("laser_tests/intensity_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/intensity_test/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
 
   ros::NodeHandle nh;
   ros::Subscriber sub_1, sub_2, sub_3;
@@ -260,10 +263,12 @@ TEST_F(LaserPluginTest, intensity_test) {
  * configurations
  */
 TEST_F(LaserPluginTest, invalid_A) {
-  world_yaml = this_file_dir / fs::path("laser_tests/invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
@@ -285,10 +290,12 @@ TEST_F(LaserPluginTest, invalid_A) {
  * configurations
  */
 TEST_F(LaserPluginTest, invalid_B) {
-  world_yaml = this_file_dir / fs::path("laser_tests/invalid_B/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("laser_tests/invalid_B/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {

--- a/flatland_plugins/test/laser_tests/intensity_test/world.yaml
+++ b/flatland_plugins/test/laser_tests/intensity_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/intensity_test/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/intensity_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../range_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/invalid_B/world.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../range_test/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/invalid_B/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/laser_tests/range_test/world.yaml
+++ b/flatland_plugins/test/laser_tests/range_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/laser_tests/range_test/world_plugins.yaml
+++ b/flatland_plugins/test/laser_tests/range_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_test.cpp
+++ b/flatland_plugins/test/model_tf_publisher_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_plugins;
 class ModelTfPublisherTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   World* w;
 
   void SetUp() override {
@@ -119,13 +119,14 @@ class ModelTfPublisherTest : public ::testing::Test {
  * Test the transformation for the model robot in a given plugin configuration
  */
 TEST_F(ModelTfPublisherTest, tf_publish_test_A) {
-  world_yaml =
-      this_file_dir /
-      fs::path("model_tf_publisher_tests/tf_publish_test_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/tf_publish_test_A/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
   ModelTfPublisher* p = dynamic_cast<ModelTfPublisher*>(
       w->plugin_manager_.model_plugins_[0].get());
 
@@ -193,13 +194,14 @@ TEST_F(ModelTfPublisherTest, tf_publish_test_A) {
  * Test the transformation for the model robot in another plugin configuration
  */
 TEST_F(ModelTfPublisherTest, tf_publish_test_B) {
-  world_yaml =
-      this_file_dir /
-      fs::path("model_tf_publisher_tests/tf_publish_test_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/tf_publish_test_B/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
   ModelTfPublisher* p = dynamic_cast<ModelTfPublisher*>(
       w->plugin_manager_.model_plugins_[0].get());
 
@@ -256,11 +258,13 @@ TEST_F(ModelTfPublisherTest, tf_publish_test_B) {
  * to a nonexistent reference body
  */
 TEST_F(ModelTfPublisherTest, invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("model_tf_publisher_tests/invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/invalid_A/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {
@@ -282,11 +286,13 @@ TEST_F(ModelTfPublisherTest, invalid_A) {
  * to a nonexistent body specified in the exclude list
  */
 TEST_F(ModelTfPublisherTest, invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("model_tf_publisher_tests/invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("model_tf_publisher_tests/invalid_B/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
 
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException& e) {

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "../tf_publish_test_A/map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world_plugins.yaml
+++ b/flatland_plugins/test/model_tf_publisher_tests/tf_publish_test_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_test.cpp
+++ b/flatland_plugins/test/tween_test.cpp
@@ -58,7 +58,7 @@ using namespace flatland_plugins;
 class TweenPluginTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
 
   void SetUp() override {
     this_file_dir = boost::filesystem::path(__FILE__).parent_path();
@@ -82,11 +82,13 @@ class TweenPluginTest : public ::testing::Test {
  * Test the tween plugin handles oneshot
  */
 TEST_F(TweenPluginTest, once_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/once.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "once.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "once.world_plugins.yaml", true);
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());
@@ -116,11 +118,13 @@ TEST_F(TweenPluginTest, once_test) {
  * Test that the tween plugin yoyos
  */
 TEST_F(TweenPluginTest, yoyo_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/yoyo.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "yoyo.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "yoyo.world_plugins.yaml", true);
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());
@@ -159,11 +163,13 @@ TEST_F(TweenPluginTest, yoyo_test) {
  * Test that the tween plugin loops
  */
 TEST_F(TweenPluginTest, loop_test) {
-  world_yaml = this_file_dir / fs::path("tween_tests/loop.world.yaml");
+  world_yaml_path = this_file_dir / fs::path("tween_tests/");
 
   Timekeeper timekeeper;
   timekeeper.SetMaxStepSize(0.5);
-  World* w = World::MakeWorld(world_yaml.string());
+  World* w = World::MakeWorld(
+      world_yaml_path.string() + "loop.world.yaml", world_yaml_path.string(),
+      world_yaml_path.string() + "loop.world_plugins.yaml", true);
 
   Tween* tween =
       dynamic_cast<Tween*>(w->plugin_manager_.model_plugins_[0].get());

--- a/flatland_plugins/test/tween_tests/loop.world.yaml
+++ b/flatland_plugins/test/tween_tests/loop.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/loop.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/loop.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_tests/once.world.yaml
+++ b/flatland_plugins/test/tween_tests/once.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/once.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/once.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/tween_tests/yoyo.world.yaml
+++ b/flatland_plugins/test/tween_tests/yoyo.world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/tween_tests/yoyo.world_plugins.yaml
+++ b/flatland_plugins/test/tween_tests/yoyo.world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_plugins/test/update_timer_test.cpp
+++ b/flatland_plugins/test/update_timer_test.cpp
@@ -77,7 +77,7 @@ class TestPlugin : public ModelPlugin {
 class UpdateTimerTest : public ::testing::Test {
  public:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   double set_rate;
   double expected_rate;
   double actual_rate;
@@ -99,7 +99,9 @@ class UpdateTimerTest : public ::testing::Test {
 
   void ExecuteRateTest() {
     Timekeeper timekeeper;
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                         world_yaml_path.string(),
+                         world_yaml_path.string() + "world_plugins.yaml", true);
 
     // artificially load a plugin
     boost::shared_ptr<TestPlugin> p(new TestPlugin());
@@ -128,7 +130,7 @@ class UpdateTimerTest : public ::testing::Test {
  * Test update rate at real time factor > 1
  */
 TEST_F(UpdateTimerTest, rate_test_A) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 141.56;
   expected_rate = set_rate;
   sim_test_time = 2.0;
@@ -146,7 +148,7 @@ TEST_F(UpdateTimerTest, rate_test_A) {
  * Test update rate at real time factor < 1
  */
 TEST_F(UpdateTimerTest, rate_test_B) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 564.56;
   expected_rate = set_rate;
   sim_test_time = 1.0;
@@ -164,7 +166,7 @@ TEST_F(UpdateTimerTest, rate_test_B) {
  * Test update rate at real time factor >> 1
  */
 TEST_F(UpdateTimerTest, rate_test_C) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 47.4;
   expected_rate = set_rate;
   sim_test_time = 2;
@@ -182,7 +184,7 @@ TEST_F(UpdateTimerTest, rate_test_C) {
  * Test update rate at update rate = inf, which will update as fast as possible
  */
 TEST_F(UpdateTimerTest, rate_test_D) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = std::numeric_limits<double>::infinity();
   expected_rate = 100.0;
   sim_test_time = 2;
@@ -200,7 +202,7 @@ TEST_F(UpdateTimerTest, rate_test_D) {
  * Test update rate at update rate = 0, which will never update
  */
 TEST_F(UpdateTimerTest, rate_test_E) {
-  world_yaml = this_file_dir / fs::path("update_timer_test/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("update_timer_test/");
   set_rate = 0;
   expected_rate = 0;
   sim_test_time = 2;

--- a/flatland_plugins/test/update_timer_test/world.yaml
+++ b/flatland_plugins/test/update_timer_test/world.yaml
@@ -1,5 +1,4 @@
-properties: {}
-layers: 
+layers:
   - name: "layer_1"
     map: "map_1.yaml"
     color: [0, 1, 0, 1]

--- a/flatland_plugins/test/update_timer_test/world_plugins.yaml
+++ b/flatland_plugins/test/update_timer_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/include/flatland_server/service_manager.h
+++ b/flatland_server/include/flatland_server/service_manager.h
@@ -44,6 +44,9 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#ifndef FLATLAND_PLUGIN_SERVICE_MANAGER_H
+#define FLATLAND_PLUGIN_SERVICE_MANAGER_H
+
 #include <flatland_msgs/DeleteModel.h>
 #include <flatland_msgs/MoveModel.h>
 #include <flatland_msgs/SpawnModel.h>
@@ -51,9 +54,6 @@
 #include <flatland_server/world.h>
 #include <ros/ros.h>
 #include <std_srvs/Empty.h>
-
-#ifndef FLATLAND_PLUGIN_SERVICE_MANAGER_H
-#define FLATLAND_PLUGIN_SERVICE_MANAGER_H
 
 namespace flatland_server {
 

--- a/flatland_server/include/flatland_server/simulation_manager.h
+++ b/flatland_server/include/flatland_server/simulation_manager.h
@@ -59,11 +59,14 @@ class SimulationManager {
  public:
   bool run_simulator_;           ///<  While true, keep running the sim loop
   World *world_;                 ///< Simulation world
+  bool use_local_map_;           ///< Whether or not to wait and poll for map updates
   double update_rate_;           ///< sim loop rate
   double step_size_;             ///< step size
   bool show_viz_;                ///< flag to determine if to show visualization
   double viz_pub_rate_;          ///< rate to publish visualization
   std::string world_yaml_file_;  ///< path to the world file
+  std::string models_path_;
+  std::string world_plugins_path_;
 
   /**
    * @name  Simulation Manager constructor
@@ -74,7 +77,7 @@ class SimulationManager {
    * @param[in] viz_pub_rate rate to publish visualization
    * behaving ones
    */
-  SimulationManager(std::string world_yaml_file, double update_rate,
+  SimulationManager(std::string world_yaml_file, std::string models_path, std::string world_plugins_path, bool use_local_map, double update_rate,
                     double step_size, bool show_viz, double viz_pub_rate);
 
   /**

--- a/flatland_server/include/flatland_server/simulation_manager.h
+++ b/flatland_server/include/flatland_server/simulation_manager.h
@@ -48,8 +48,8 @@
 #define FLATLAND_SERVER_SIMULATION_MANAGER_H
 
 #include <Box2D/Box2D.h>
-#include <flatland_server/service_manager.h>
 #include <flatland_server/debug_visualization.h>
+#include <flatland_server/service_manager.h>
 #include <flatland_server/timekeeper.h>
 #include <flatland_server/world.h>
 #include <std_msgs/Empty.h>
@@ -60,13 +60,13 @@ namespace flatland_server {
 class ServiceManager;
 class SimulationManager {
  public:
-  bool run_simulator_;           ///<  While true, keep running the sim loop
-  World *world_;                 ///< Simulation world
-  bool use_local_map_;           ///< Whether or not to wait and poll for map updates
-  double update_rate_;           ///< sim loop rate
-  double step_size_;             ///< step size
-  bool show_viz_;                ///< flag to determine if to show visualization
-  double viz_pub_rate_;          ///< rate to publish visualization
+  bool run_simulator_;   ///<  While true, keep running the sim loop
+  World* world_;         ///< Simulation world
+  bool use_local_map_;   ///< Whether or not to wait and poll for map updates
+  double update_rate_;   ///< sim loop rate
+  double step_size_;     ///< step size
+  bool show_viz_;        ///< flag to determine if to show visualization
+  double viz_pub_rate_;  ///< rate to publish visualization
   std::string world_yaml_file_;  ///< path to the world file
   std::string models_path_;
   std::string world_plugins_path_;
@@ -84,17 +84,19 @@ class SimulationManager {
    * @param[in] viz_pub_rate rate to publish visualization
    * behaving ones
    */
-  SimulationManager(std::string world_yaml_file, std::string models_path, std::string world_plugins_path, bool use_local_map, double update_rate,
-                    double step_size, bool show_viz, double viz_pub_rate);
+  SimulationManager(std::string world_yaml_file, std::string models_path,
+                    std::string world_plugins_path, bool use_local_map,
+                    double update_rate, double step_size, bool show_viz,
+                    double viz_pub_rate);
 
   /**
    * This method contains the loop that runs the simulation
    */
   void Main();
 
-   /**
-   * Updates the map of the world
-   */
+  /**
+  * Updates the map of the world
+  */
   void UpdateMap(const std_msgs::Empty::ConstPtr& map_changed);
 
   /**

--- a/flatland_server/include/flatland_server/simulation_manager.h
+++ b/flatland_server/include/flatland_server/simulation_manager.h
@@ -48,13 +48,16 @@
 #define FLATLAND_SERVER_SIMULATION_MANAGER_H
 
 #include <Box2D/Box2D.h>
+#include <flatland_server/service_manager.h>
 #include <flatland_server/debug_visualization.h>
 #include <flatland_server/timekeeper.h>
 #include <flatland_server/world.h>
+#include <std_msgs/Empty.h>
 #include <string>
 
 namespace flatland_server {
 
+class ServiceManager;
 class SimulationManager {
  public:
   bool run_simulator_;           ///<  While true, keep running the sim loop
@@ -67,6 +70,10 @@ class SimulationManager {
   std::string world_yaml_file_;  ///< path to the world file
   std::string models_path_;
   std::string world_plugins_path_;
+
+  ros::Subscriber map_changed_subscriber_;
+  ros::NodeHandle nh_;
+  std::unique_ptr<flatland_server::ServiceManager> service_manager_;
 
   /**
    * @name  Simulation Manager constructor
@@ -84,6 +91,11 @@ class SimulationManager {
    * This method contains the loop that runs the simulation
    */
   void Main();
+
+   /**
+   * Updates the map of the world
+   */
+  void UpdateMap(const std_msgs::Empty::ConstPtr& map_changed);
 
   /**
    * Kill the world

--- a/flatland_server/include/flatland_server/world.h
+++ b/flatland_server/include/flatland_server/world.h
@@ -216,19 +216,22 @@ class World : public b2ContactListener {
    * @param[in] world_plugins_path Path to the world yaml file
    * @return pointer to a new world
    */
-  static World *MakeWorld(const std::string &yaml_path, const std::string &models_path, const std::string &world_plugins_path, const bool use_local_map);
+  static World *MakeWorld(const std::string &yaml_path,
+                          const std::string &models_path,
+                          const std::string &world_plugins_path,
+                          const bool use_local_map);
 
-    /**
-     * @brief Loads the layers and objects in the world
-     * @param[in] yaml_path Path to the world yaml file
-     */
+  /**
+   * @brief Loads the layers and objects in the world
+   * @param[in] yaml_path Path to the world yaml file
+   */
   void LoadWorldEntities(const std::string &yaml_path);
 
-    /**
-   * @brief Publish debug visualizations for everything
-   * @param[in] update_layers since layers are pretty much static, this
-   * parameter is used to skip updating layers
-   */
+  /**
+ * @brief Publish debug visualizations for everything
+ * @param[in] update_layers since layers are pretty much static, this
+ * parameter is used to skip updating layers
+ */
   void DebugVisualize(bool update_layers = true);
 };
 };      // namespace flatland_server

--- a/flatland_server/include/flatland_server/world.h
+++ b/flatland_server/include/flatland_server/world.h
@@ -91,6 +91,9 @@ class World : public b2ContactListener {
 
   MessageServer message_server;
 
+  std::string models_path_;
+  bool use_local_map_;
+
   /**
    * @brief Constructor for the world class. All data required for
    * initialization should be passed in here
@@ -209,11 +212,19 @@ class World : public b2ContactListener {
    * @brief factory method to create a instance of the world class. Cleans all
    * the inputs before instantiation of the class. TThrows YAMLException.
    * @param[in] yaml_path Path to the world yaml file
+   * @param[in] models_path Path to the world yaml file
+   * @param[in] world_plugins_path Path to the world yaml file
    * @return pointer to a new world
    */
-  static World *MakeWorld(const std::string &yaml_path);
+  static World *MakeWorld(const std::string &yaml_path, const std::string &models_path, const std::string &world_plugins_path, const bool use_local_map);
 
-  /**
+    /**
+     * @brief Loads the layers and objects in the world
+     * @param[in] yaml_path Path to the world yaml file
+     */
+  void LoadWorldEntities(const std::string &yaml_path);
+
+    /**
    * @brief Publish debug visualizations for everything
    * @param[in] update_layers since layers are pretty much static, this
    * parameter is used to skip updating layers

--- a/flatland_server/launch/server.launch
+++ b/flatland_server/launch/server.launch
@@ -9,7 +9,8 @@
   <arg name="step_size" default="0.005"/>
   <arg name="show_viz" default="true"/>
   <arg name="viz_pub_rate" default="30.0"/>
-  <arg name="use_rviz" default="false"/>  
+  <arg name="use_rviz" default="false"/>
+  <arg name="use_local_map" default="true" />
 
   <env name="ROSCONSOLE_FORMAT" value="[${severity} ${time} ${logger}]: ${message}" />
 
@@ -23,7 +24,8 @@
     <param name="step_size" value="$(arg step_size)" />
     <param name="show_viz" value="$(arg show_viz)" />
     <param name="viz_pub_rate" value="$(arg viz_pub_rate)" />
-    
+    <param name="use_local_map" value="$(arg use_local_map)" />
+
   </node>
 
 <group if="$(arg show_viz)">

--- a/flatland_server/src/flatland_server_node.cpp
+++ b/flatland_server/src/flatland_server_node.cpp
@@ -78,9 +78,30 @@ int main(int argc, char **argv) {
   ros::init(argc, argv, "flatland", ros::init_options::NoSigintHandler);
   ros::NodeHandle node_handle("~");
 
+  bool use_local_map = true;
+  if (!node_handle.getParam("use_local_map", use_local_map)) {
+    ROS_WARN_STREAM_NAMED("Node", "use_local_map argument not found");
+  }
+
   // Load parameters
-  std::string world_path;  // The file path to the world.yaml file
-  if (!node_handle.getParam("world_path", world_path)) {
+  std::string world_path = "";  // The file path to the world.yaml file
+  if (use_local_map) {
+    if (!node_handle.getParam("world_path", world_path)) {
+      ROS_FATAL_NAMED("Node", "No world_path parameter given!");
+      ros::shutdown();
+      return 1;
+    }
+  }
+
+  std::string models_path;
+  if (!node_handle.getParam("models_path", models_path)) {
+    ROS_FATAL_NAMED("Node", "No world_path parameter given!");
+    ros::shutdown();
+    return 1;
+  }
+
+  std::string world_plugins_path;
+  if (!node_handle.getParam("world_plugins_path", world_plugins_path)) {
     ROS_FATAL_NAMED("Node", "No world_path parameter given!");
     ros::shutdown();
     return 1;
@@ -100,7 +121,7 @@ int main(int argc, char **argv) {
 
   // Create simulation manager object
   simulation_manager = new flatland_server::SimulationManager(
-      world_path, update_rate, step_size, show_viz, viz_pub_rate);
+      world_path, models_path, world_plugins_path, use_local_map, update_rate, step_size, show_viz, viz_pub_rate);
 
   // Register sigint shutdown handler
   signal(SIGINT, SigintHandler);

--- a/flatland_server/src/flatland_server_node.cpp
+++ b/flatland_server/src/flatland_server_node.cpp
@@ -119,7 +119,8 @@ int main(int argc, char **argv) {
 
   // Create simulation manager object
   simulation_manager = new flatland_server::SimulationManager(
-      world_path, models_path, world_plugins_path, use_local_map, update_rate, step_size, show_viz, viz_pub_rate);
+      world_path, models_path, world_plugins_path, use_local_map, update_rate,
+      step_size, show_viz, viz_pub_rate);
 
   // Register sigint shutdown handler
   signal(SIGINT, SigintHandler);

--- a/flatland_server/src/flatland_server_node.cpp
+++ b/flatland_server/src/flatland_server_node.cpp
@@ -85,12 +85,10 @@ int main(int argc, char **argv) {
 
   // Load parameters
   std::string world_path = "";  // The file path to the world.yaml file
-  if (use_local_map) {
-    if (!node_handle.getParam("world_path", world_path)) {
-      ROS_FATAL_NAMED("Node", "No world_path parameter given!");
-      ros::shutdown();
-      return 1;
-    }
+  if (!node_handle.getParam("world_path", world_path)) {
+    ROS_FATAL_NAMED("Node", "No world_path parameter given!");
+    ros::shutdown();
+    return 1;
   }
 
   std::string models_path;

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -202,7 +202,6 @@ void PluginManager::LoadWorldPlugin(World *world, YamlReader &plugin_reader,
           world_plugin_loader_->createInstance("flatland_plugins::" + type);
     }
   } catch (pluginlib::PluginlibException &e) {
-    std::cout << "WTF" << std::endl;
     throw PluginException(msg + ": " + std::string(e.what()));
   }
 

--- a/flatland_server/src/plugin_manager.cpp
+++ b/flatland_server/src/plugin_manager.cpp
@@ -185,7 +185,6 @@ void PluginManager::LoadWorldPlugin(World *world, YamlReader &plugin_reader,
 
   boost::shared_ptr<WorldPlugin> world_plugin;
   std::string msg = "World Plugin " + Q(name) + " type " + Q(type);
-
   YAML::Node yaml_node;
   for (const auto &k : plugin_reader.Node()) {
     if (k.first.as<std::string>() != "name" &&
@@ -203,6 +202,7 @@ void PluginManager::LoadWorldPlugin(World *world, YamlReader &plugin_reader,
           world_plugin_loader_->createInstance("flatland_plugins::" + type);
     }
   } catch (pluginlib::PluginlibException &e) {
+    std::cout << "WTF" << std::endl;
     throw PluginException(msg + ": " + std::string(e.what()));
   }
 

--- a/flatland_server/src/simulation_manager.cpp
+++ b/flatland_server/src/simulation_manager.cpp
@@ -57,15 +57,18 @@
 
 namespace flatland_server {
 
-SimulationManager::SimulationManager(std::string world_yaml_file,
+SimulationManager::SimulationManager(std::string world_yaml_file, std::string models_path, std::string world_plugins_path, bool use_local_map,
                                      double update_rate, double step_size,
                                      bool show_viz, double viz_pub_rate)
     : world_(nullptr),
+      use_local_map_(use_local_map),
       update_rate_(update_rate),
       step_size_(step_size),
       show_viz_(show_viz),
       viz_pub_rate_(viz_pub_rate),
-      world_yaml_file_(world_yaml_file) {
+      world_yaml_file_(world_yaml_file),
+      models_path_(models_path),
+      world_plugins_path_(world_plugins_path) {
   ROS_INFO_NAMED("SimMan",
                  "Simulation params: world_yaml_file(%s) update_rate(%f), "
                  "step_size(%f) show_viz(%s), viz_pub_rate(%f)",
@@ -78,7 +81,7 @@ void SimulationManager::Main() {
   run_simulator_ = true;
 
   try {
-    world_ = World::MakeWorld(world_yaml_file_);
+    world_ = World::MakeWorld(world_yaml_file_, models_path_, world_plugins_path_, use_local_map_);
     ROS_INFO_NAMED("SimMan", "World loaded");
   } catch (const std::exception& e) {
     ROS_FATAL_NAMED("SimMan", "%s", e.what());

--- a/flatland_server/src/simulation_manager.cpp
+++ b/flatland_server/src/simulation_manager.cpp
@@ -44,10 +44,10 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <flatland_server/simulation_manager.h>
 #include <flatland_server/debug_visualization.h>
 #include <flatland_server/layer.h>
 #include <flatland_server/model.h>
+#include <flatland_server/simulation_manager.h>
 #include <flatland_server/world.h>
 #include <ros/ros.h>
 #include <exception>
@@ -56,9 +56,12 @@
 
 namespace flatland_server {
 
-SimulationManager::SimulationManager(std::string world_yaml_file, std::string models_path, std::string world_plugins_path, bool use_local_map,
-                                     double update_rate, double step_size,
-                                     bool show_viz, double viz_pub_rate)
+SimulationManager::SimulationManager(std::string world_yaml_file,
+                                     std::string models_path,
+                                     std::string world_plugins_path,
+                                     bool use_local_map, double update_rate,
+                                     double step_size, bool show_viz,
+                                     double viz_pub_rate)
     : world_(nullptr),
       use_local_map_(use_local_map),
       update_rate_(update_rate),
@@ -80,7 +83,8 @@ void SimulationManager::Main() {
   run_simulator_ = true;
 
   try {
-    world_ = World::MakeWorld(world_yaml_file_, models_path_, world_plugins_path_, use_local_map_);
+    world_ = World::MakeWorld(world_yaml_file_, models_path_,
+                              world_plugins_path_, use_local_map_);
     ROS_INFO_NAMED("SimMan", "World loaded");
   } catch (const std::exception& e) {
     ROS_FATAL_NAMED("SimMan", "%s", e.what());
@@ -88,9 +92,11 @@ void SimulationManager::Main() {
   }
 
   if (!use_local_map_) {
-    map_changed_subscriber_ = nh_.subscribe("/map_changed", 1, &SimulationManager::UpdateMap, this);
+    map_changed_subscriber_ =
+        nh_.subscribe("/map_changed", 1, &SimulationManager::UpdateMap, this);
   } else {
-    service_manager_ = std::unique_ptr<ServiceManager>(new ServiceManager(this, world_));
+    service_manager_ =
+        std::unique_ptr<ServiceManager>(new ServiceManager(this, world_));
   }
 
   if (show_viz_) world_->DebugVisualize();
@@ -150,12 +156,14 @@ void SimulationManager::Main() {
   delete world_;
 }
 
-void SimulationManager::UpdateMap(const std_msgs::Empty::ConstPtr& map_changed) {
+void SimulationManager::UpdateMap(
+    const std_msgs::Empty::ConstPtr& map_changed) {
   world_->LoadWorldEntities(world_yaml_file_);
   if (show_viz_) world_->DebugVisualize();
 
   if (service_manager_ == nullptr) {
-    service_manager_ = std::unique_ptr<ServiceManager>(new ServiceManager(this, world_));
+    service_manager_ =
+        std::unique_ptr<ServiceManager>(new ServiceManager(this, world_));
   }
 }
 

--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -127,10 +127,15 @@ void World::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) {
   plugin_manager_.PostSolve(contact, impulse);
 }
 
-World *World::MakeWorld(const std::string &yaml_path, const std::string &models_path, const std::string &world_plugins_path, const bool use_local_map) {
+World *World::MakeWorld(const std::string &yaml_path,
+                        const std::string &models_path,
+                        const std::string &world_plugins_path,
+                        const bool use_local_map) {
   YamlReader world_settings_reader = YamlReader(world_plugins_path);
-  YamlReader prop_reader = world_settings_reader.Subnode("properties", YamlReader::MAP);
-  YamlReader world_plugin_reader = world_settings_reader.SubnodeOpt("plugins", YamlReader::LIST);
+  YamlReader prop_reader =
+      world_settings_reader.Subnode("properties", YamlReader::MAP);
+  YamlReader world_plugin_reader =
+      world_settings_reader.SubnodeOpt("plugins", YamlReader::LIST);
 
   int v = prop_reader.Get<int>("velocity_iterations", 10);
   int p = prop_reader.Get<int>("position_iterations", 10);
@@ -169,14 +174,16 @@ World *World::MakeWorld(const std::string &yaml_path, const std::string &models_
   return w;
 }
 
-void World::LoadWorldEntities(const std::string& yaml_path) {
+void World::LoadWorldEntities(const std::string &yaml_path) {
   try {
-      YamlReader map_info_reader = YamlReader(yaml_path);
-      YamlReader layers_reader = map_info_reader.Subnode("layers", YamlReader::LIST);
-      YamlReader models_reader = map_info_reader.SubnodeOpt("models", YamlReader::LIST);
+    YamlReader map_info_reader = YamlReader(yaml_path);
+    YamlReader layers_reader =
+        map_info_reader.Subnode("layers", YamlReader::LIST);
+    YamlReader models_reader =
+        map_info_reader.SubnodeOpt("models", YamlReader::LIST);
 
-      this->LoadLayers(layers_reader);
-      this->LoadModels(models_reader);
+    this->LoadLayers(layers_reader);
+    this->LoadModels(models_reader);
 
   } catch (const YAMLException &e) {
     ROS_FATAL_NAMED("World", "Error loading from YAML");

--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -127,9 +127,11 @@ void World::PostSolve(b2Contact *contact, const b2ContactImpulse *impulse) {
   plugin_manager_.PostSolve(contact, impulse);
 }
 
-World *World::MakeWorld(const std::string &yaml_path) {
-  YamlReader world_reader = YamlReader(yaml_path);
-  YamlReader prop_reader = world_reader.Subnode("properties", YamlReader::MAP);
+World *World::MakeWorld(const std::string &yaml_path, const std::string &models_path, const std::string &world_plugins_path, const bool use_local_map) {
+  YamlReader world_settings_reader = YamlReader(world_plugins_path);
+  YamlReader prop_reader = world_settings_reader.Subnode("properties", YamlReader::MAP);
+  YamlReader world_plugin_reader = world_settings_reader.SubnodeOpt("plugins", YamlReader::LIST);
+
   int v = prop_reader.Get<int>("velocity_iterations", 10);
   int p = prop_reader.Get<int>("position_iterations", 10);
   prop_reader.EnsureAccessedAllKeys();
@@ -139,17 +141,19 @@ World *World::MakeWorld(const std::string &yaml_path) {
   w->world_yaml_dir_ = boost::filesystem::path(yaml_path).parent_path();
   w->physics_velocity_iterations_ = v;
   w->physics_position_iterations_ = p;
+  w->models_path_ = models_path;
+  w->use_local_map_ = use_local_map;
 
   try {
-    YamlReader layers_reader = world_reader.Subnode("layers", YamlReader::LIST);
-    YamlReader models_reader =
-        world_reader.SubnodeOpt("models", YamlReader::LIST);
-    YamlReader world_plugin_reader =
-        world_reader.SubnodeOpt("plugins", YamlReader::LIST);
-    world_reader.EnsureAccessedAllKeys();
-    w->LoadLayers(layers_reader);
-    w->LoadModels(models_reader);
-    w->LoadWorldPlugins(world_plugin_reader, w, world_reader);
+
+    if (use_local_map) {
+      w->LoadWorldEntities(yaml_path);
+    }
+
+    w->LoadWorldPlugins(world_plugin_reader, w, world_settings_reader);
+
+    world_settings_reader.EnsureAccessedAllKeys();
+
   } catch (const YAMLException &e) {
     ROS_FATAL_NAMED("World", "Error loading from YAML");
     delete w;
@@ -164,6 +168,27 @@ World *World::MakeWorld(const std::string &yaml_path) {
     throw e;
   }
   return w;
+}
+
+void World::LoadWorldEntities(const std::string& yaml_path) {
+  try {
+      YamlReader map_info_reader = YamlReader(yaml_path);
+      YamlReader layers_reader = map_info_reader.Subnode("layers", YamlReader::LIST);
+      YamlReader models_reader = map_info_reader.SubnodeOpt("models", YamlReader::LIST);
+
+      this->LoadLayers(layers_reader);
+      this->LoadModels(models_reader);
+
+  } catch (const YAMLException &e) {
+    ROS_FATAL_NAMED("World", "Error loading from YAML");
+    throw e;
+  } catch (const PluginException &e) {
+    ROS_FATAL_NAMED("World", "Error loading plugins");
+    throw e;
+  } catch (const Exception &e) {
+    ROS_FATAL_NAMED("World", "Error loading world");
+    throw e;
+  }
 }
 
 void World::LoadLayers(YamlReader &layers_reader) {
@@ -235,7 +260,7 @@ void World::LoadModels(YamlReader &models_reader) {
         throw YAMLException("Model with name " + Q(name) + " already exists");
       }
 
-      LoadModel(path, ns, name, pose);
+      LoadModel(models_path_ + "/" + path, ns, name, pose);
     }
   }
 }

--- a/flatland_server/src/world.cpp
+++ b/flatland_server/src/world.cpp
@@ -145,12 +145,11 @@ World *World::MakeWorld(const std::string &yaml_path, const std::string &models_
   w->use_local_map_ = use_local_map;
 
   try {
+    w->LoadWorldPlugins(world_plugin_reader, w, world_settings_reader);
 
     if (use_local_map) {
       w->LoadWorldEntities(yaml_path);
     }
-
-    w->LoadWorldPlugins(world_plugin_reader, w, world_settings_reader);
 
     world_settings_reader.EnsureAccessedAllKeys();
 

--- a/flatland_server/test/conestogo_office_test/world.yaml
+++ b/flatland_server/test/conestogo_office_test/world.yaml
@@ -1,4 +1,3 @@
-properties: {} # For later use
 layers:  # Support for arbitrary number of layers
   - name: "2d"  # layer 0 named "2d"
     map: "map.yaml"  # leading / denotes absolute file path, otherwise relative
@@ -16,17 +15,3 @@ models:
   - name: sensor
     pose: [2, 0, 0]
     model: "sensor.model.yaml"
-plugins:
-  - name: test1
-    type: RandomWall
-    layer: "2d"
-    num_of_walls: 10
-    wall_wall_dist: 1
-    double_wall: true
-    robot_name: cleaner1
-
-
-  # - name: turtlebot1 
-  #   pose: [12, 0, 0]
-  #   model: "turtlebot.model.yaml"
-    

--- a/flatland_server/test/conestogo_office_test/world_plugins.yaml
+++ b/flatland_server/test/conestogo_office_test/world_plugins.yaml
@@ -1,0 +1,9 @@
+properties: {}
+plugins:
+  - name: test1
+    type: RandomWall
+    layer: "2d"
+    num_of_walls: 10
+    wall_wall_dist: 1
+    double_wall: true
+    robot_name: cleaner1

--- a/flatland_server/test/load_world_test.cpp
+++ b/flatland_server/test/load_world_test.cpp
@@ -62,7 +62,7 @@ using namespace flatland_server;
 class LoadWorldTest : public ::testing::Test {
  protected:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_path;
   World *w;
 
   void SetUp() override {
@@ -84,7 +84,9 @@ class LoadWorldTest : public ::testing::Test {
     std::regex regex(regex_str);
 
     try {
-      w = World::MakeWorld(world_yaml.string());
+      w = World::MakeWorld(
+          world_yaml_path.string() + "world.yaml", world_yaml_path.string(),
+          world_yaml_path.string() + "world_plugins.yaml", true);
       ADD_FAILURE() << "Expected an exception, but none were raised";
     } catch (const Exception &e) {
       EXPECT_TRUE(std::regex_match(e.what(), match, regex))
@@ -514,9 +516,10 @@ class LoadWorldTest : public ::testing::Test {
  * correct after instantiation
  */
 TEST_F(LoadWorldTest, simple_test_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
-  w = World::MakeWorld(world_yaml.string());
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
+  w = World::MakeWorld(world_yaml_path.string() + "world.yaml",
+                       world_yaml_path.string(),
+                       world_yaml_path.string() + "world_plugins.yaml", true);
 
   EXPECT_EQ(w->physics_velocity_iterations_, 11);
   EXPECT_EQ(w->physics_position_iterations_, 12);
@@ -753,11 +756,11 @@ TEST_F(LoadWorldTest, simple_test_A) {
  * an exception
  */
 TEST_F(LoadWorldTest, wrong_world_path) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/random_path/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/random_path/");
+
   test_yaml_fail(
       "Flatland YAML: File does not exist, "
-      "path=\".*/load_world_tests/random_path/world.yaml\".*");
+      "path=\".*/load_world_tests/random_path/world_plugins.yaml\".*");
 }
 
 /**
@@ -765,8 +768,8 @@ TEST_F(LoadWorldTest, wrong_world_path) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_A/");
   test_yaml_fail("Flatland YAML: Entry \"properties\" does not exist");
 }
 
@@ -775,8 +778,8 @@ TEST_F(LoadWorldTest, world_invalid_A) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_B/");
   test_yaml_fail(
       "Flatland YAML: Entry \"color\" must have size of exactly 4 \\(in "
       "\"layers\" index=0\\)");
@@ -787,8 +790,8 @@ TEST_F(LoadWorldTest, world_invalid_B) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_C/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_C/");
   test_yaml_fail(
       "Flatland YAML: Entry index=0 contains unrecognized entry\\(s\\) "
       "\\{\"random_param_1\", \"random_param_2\", \"random_param_3\"\\} \\(in "
@@ -800,8 +803,8 @@ TEST_F(LoadWorldTest, world_invalid_C) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_D/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_D/");
   test_yaml_fail("Flatland YAML: Layer with name \"layer\" already exists");
 }
 
@@ -810,8 +813,8 @@ TEST_F(LoadWorldTest, world_invalid_D) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_E/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_E/");
   test_yaml_fail("Flatland YAML: Model with name \"turtlebot\" already exists");
 }
 
@@ -820,8 +823,8 @@ TEST_F(LoadWorldTest, world_invalid_E) {
  * an exception.
  */
 TEST_F(LoadWorldTest, world_invalid_F) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/world_invalid_F/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/world_invalid_F/");
   test_yaml_fail(
       "Flatland YAML: Unable to add 3 additional layer\\(s\\) \\{layer_15, "
       "layer_16, layer_17\\}, current layers count is 14, max allowed is 16");
@@ -832,8 +835,7 @@ TEST_F(LoadWorldTest, world_invalid_F) {
  * load a invalid map yaml file. It should throw an exception.
  */
 TEST_F(LoadWorldTest, map_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_A/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_A/");
   test_yaml_fail(
       "Flatland YAML: Entry \"origin\" does not exist \\(in layer "
       "\"2d\"\\)");
@@ -845,8 +847,7 @@ TEST_F(LoadWorldTest, map_invalid_A) {
  * throw an exception
  */
 TEST_F(LoadWorldTest, map_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_B/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_B/");
   test_yaml_fail("Flatland YAML: Failed to load \".*\\.png\" in layer \"2d\"");
 }
 
@@ -855,8 +856,7 @@ TEST_F(LoadWorldTest, map_invalid_B) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_C/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_C/");
   test_yaml_fail(
       "Flatland File: Failed to load \".*/map_invalid_C/random_file.dat\"");
 }
@@ -866,8 +866,7 @@ TEST_F(LoadWorldTest, map_invalid_C) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_D/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_D/");
   test_yaml_fail(
       "Flatland File: Failed to read line segment from line 6, in file "
       "\"map_lines.dat\"");
@@ -878,8 +877,7 @@ TEST_F(LoadWorldTest, map_invalid_D) {
  * thrown
  */
 TEST_F(LoadWorldTest, map_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/map_invalid_E/world.yaml");
+  world_yaml_path = this_file_dir / fs::path("load_world_tests/map_invalid_E/");
   test_yaml_fail(
       "Flatland YAML: Entry \"scale\" does not exist \\(in layer \"lines\"\\)");
 }
@@ -888,8 +886,8 @@ TEST_F(LoadWorldTest, map_invalid_E) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_A) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_A/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_A/");
   test_yaml_fail(
       "Flatland YAML: Entry \"bodies\" must be a list \\(in model "
       "\"turtlebot\"\\)");
@@ -899,8 +897,8 @@ TEST_F(LoadWorldTest, model_invalid_A) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_B) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_B/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_B/");
   test_yaml_fail(
       "Flatland YAML: Entry \"points\" must have size >= 3 \\(in model "
       "\"turtlebot\" body \"base\" \"footprints\" index=1\\)");
@@ -910,8 +908,8 @@ TEST_F(LoadWorldTest, model_invalid_B) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_C) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_C/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_C/");
   test_yaml_fail(
       "Flatland YAML: Entry \"anchor\" must have size of exactly 2 \\(in model "
       "\"turtlebot\" joint \"right_wheel_weld\" \"bodies\" index=1\\)");
@@ -921,8 +919,8 @@ TEST_F(LoadWorldTest, model_invalid_C) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_D) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_D/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_D/");
   test_yaml_fail(
       "Flatland YAML: Cannot find body with name \"left_wheel_123\" in model "
       "\"turtlebot\" joint \"left_wheel_weld\" \"bodies\" index=1");
@@ -932,8 +930,8 @@ TEST_F(LoadWorldTest, model_invalid_D) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_E) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_E/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_E/");
   test_yaml_fail(
       "Flatland YAML: Invalid footprint \"layers\" in model \"turtlebot\" body "
       "\"left_wheel\" \"footprints\" index=0, \\{random_layer\\} layer\\(s\\) "
@@ -944,8 +942,8 @@ TEST_F(LoadWorldTest, model_invalid_E) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_F) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_F/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_F/");
   test_yaml_fail(
       "Flatland YAML: Entry index=0 contains unrecognized entry\\(s\\) "
       "\\{\"random_paramter\"\\} \\(in model \"turtlebot\" body \"base\" "
@@ -956,8 +954,8 @@ TEST_F(LoadWorldTest, model_invalid_F) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_G) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_G/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_G/");
   test_yaml_fail(
       "Flatland YAML: Entry body \"base\" contains unrecognized entry\\(s\\) "
       "\\{\"random_paramter\"\\} \\(in model \"turtlebot\"\\)");
@@ -967,8 +965,8 @@ TEST_F(LoadWorldTest, model_invalid_G) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_H) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_H/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_H/");
   test_yaml_fail(
       "Flatland YAML: Invalid \"bodies\" in \"turtlebot\" model, body with "
       "name \"base\" already exists");
@@ -978,8 +976,8 @@ TEST_F(LoadWorldTest, model_invalid_H) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_I) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_I/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_I/");
   test_yaml_fail(
       "Flatland YAML: Invalid \"joints\" in \"turtlebot\" model, joint with "
       "name \"wheel_weld\" already exists");
@@ -989,8 +987,8 @@ TEST_F(LoadWorldTest, model_invalid_I) {
  * This test tries to load a invalid model yaml file, it should fail
  */
 TEST_F(LoadWorldTest, model_invalid_J) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/model_invalid_J/world.yaml");
+  world_yaml_path =
+      this_file_dir / fs::path("load_world_tests/model_invalid_J/");
   test_yaml_fail(
       "Flatland YAML: Entry \"points\" must have size <= 8 \\(in model "
       "\"turtlebot\" body \"base\" \"footprints\" index=1\\)");

--- a/flatland_server/test/load_world_tests/map_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/map_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/map_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/map_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/model_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_F/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_F/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_F/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_F/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_G/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_G/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_G/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_G/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_H/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_H/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_H/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_H/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_I/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_I/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_I/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_I/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/model_invalid_J/world.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_J/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers: []
 models: 
   - name: turtlebot

--- a/flatland_server/test/load_world_tests/model_invalid_J/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/model_invalid_J/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/simple_test_A/world.yaml
+++ b/flatland_server/test/load_world_tests/simple_test_A/world.yaml
@@ -1,6 +1,3 @@
-properties: 
-  velocity_iterations: 11
-  position_iterations: 12
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/simple_test_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/simple_test_A/world_plugins.yaml
@@ -1,0 +1,3 @@
+properties:
+  velocity_iterations: 11
+  position_iterations: 12

--- a/flatland_server/test/load_world_tests/world_invalid_A/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_A/world.yaml
@@ -1,4 +1,3 @@
-properties_____: {} # invalid
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_A/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_A/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties_____: {} # invalid

--- a/flatland_server/test/load_world_tests/world_invalid_B/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_B/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_B/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_B/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_C/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_C/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_C/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_C/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_D/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_D/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "layer"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_D/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_D/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_E/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_E/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../simple_test_A/map.yaml"

--- a/flatland_server/test/load_world_tests/world_invalid_E/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_E/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/load_world_tests/world_invalid_F/world.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_F/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - {name: "layer_1", map: "../simple_test_A/map.yaml"}
   - {name: ["layer_2", "layer_3", "layer_4"], map: "../simple_test_A/map.yaml"}

--- a/flatland_server/test/load_world_tests/world_invalid_F/world_plugins.yaml
+++ b/flatland_server/test/load_world_tests/world_invalid_F/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_test.cpp
+++ b/flatland_server/test/plugin_manager_test.cpp
@@ -118,7 +118,8 @@ class TestModelPlugin : public ModelPlugin {
 class PluginManagerTest : public ::testing::Test {
  protected:
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_yaml_dir;
+
   Timekeeper timekeeper;
   World *w;
 
@@ -178,10 +179,13 @@ class PluginManagerTest : public ::testing::Test {
  * called with the expected inputs
  */
 TEST_F(PluginManagerTest, collision_test) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/collision_test/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/collision_test/");
+
   timekeeper.SetMaxStepSize(1.0);
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                       world_yaml_dir.string(),
+                       world_yaml_dir.string() + "world_plugins.yaml", true);
   Layer *l = w->layers_[0];
   Model *m0 = w->models_[0];
   Model *m1 = w->models_[1];
@@ -299,10 +303,12 @@ TEST_F(PluginManagerTest, collision_test) {
 }
 
 TEST_F(PluginManagerTest, load_dummy_test) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
-  w = World::MakeWorld(world_yaml.string());
+  w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                       world_yaml_dir.string(),
+                       world_yaml_dir.string() + "world_plugins.yaml", true);
 
   ModelPlugin *p = w->plugin_manager_.model_plugins_[0].get();
 
@@ -311,12 +317,13 @@ TEST_F(PluginManagerTest, load_dummy_test) {
 }
 
 TEST_F(PluginManagerTest, plugin_throws_exception) {
-  world_yaml =
-      this_file_dir /
-      fs::path("plugin_manager_tests/plugin_throws_exception/world.yaml");
-
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/plugin_throws_exception/");
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml", true);
+
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException &e) {
     // do a regex match against error message
@@ -336,11 +343,14 @@ TEST_F(PluginManagerTest, plugin_throws_exception) {
 }
 
 TEST_F(PluginManagerTest, nonexistent_plugin) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/nonexistent_plugin/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/nonexistent_plugin/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml", true);
+
     FAIL() << "Expected an exception, but none were raised";
   } catch (const PluginException &e) {
     std::cmatch match;
@@ -359,11 +369,13 @@ TEST_F(PluginManagerTest, nonexistent_plugin) {
 }
 
 TEST_F(PluginManagerTest, invalid_plugin_yaml) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/invalid_plugin_yaml/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/invalid_plugin_yaml/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml", true);
     FAIL() << "Expected an exception, but none were raised";
   } catch (const YAMLException &e) {
     EXPECT_STREQ(
@@ -378,11 +390,14 @@ TEST_F(PluginManagerTest, invalid_plugin_yaml) {
 }
 
 TEST_F(PluginManagerTest, duplicate_plugin) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/duplicate_plugin/world.yaml");
+  world_yaml_dir =
+      this_file_dir / fs::path("plugin_manager_tests/duplicate_plugin/");
 
   try {
-    w = World::MakeWorld(world_yaml.string());
+    w = World::MakeWorld(world_yaml_dir.string() + "world.yaml",
+                         world_yaml_dir.string(),
+                         world_yaml_dir.string() + "world_plugins.yaml", true);
+
     FAIL() << "Expected an exception, but none were raised";
   } catch (const YAMLException &e) {
     EXPECT_STREQ(

--- a/flatland_server/test/plugin_manager_tests/collision_test/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/collision_test/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/collision_test/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/collision_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/duplicate_plugin/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/duplicate_plugin/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/duplicate_plugin/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/duplicate_plugin/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/invalid_plugin_yaml/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/load_dummy_test/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/load_dummy_test/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "map.yaml"

--- a/flatland_server/test/plugin_manager_tests/load_dummy_test/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/load_dummy_test/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/nonexistent_plugin/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world.yaml
+++ b/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world.yaml
@@ -1,4 +1,3 @@
-properties: {}
 layers:
   - name: "2d"
     map: "../load_dummy_test/map.yaml"

--- a/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world_plugins.yaml
+++ b/flatland_server/test/plugin_manager_tests/plugin_throws_exception/world_plugins.yaml
@@ -1,0 +1,1 @@
+properties: {}

--- a/flatland_server/test/service_manager_test.cpp
+++ b/flatland_server/test/service_manager_test.cpp
@@ -61,7 +61,7 @@ class ServiceManagerTest : public ::testing::Test {
  protected:
   SimulationManager* sim_man;
   boost::filesystem::path this_file_dir;
-  boost::filesystem::path world_yaml;
+  boost::filesystem::path world_path;
   boost::filesystem::path robot_yaml;
   Timekeeper timekeeper;
   ros::NodeHandle nh;
@@ -80,8 +80,10 @@ class ServiceManagerTest : public ::testing::Test {
   }
 
   void StartSimulationThread() {
-    sim_man =
-        new SimulationManager(world_yaml.string(), 1000, 1 / 1000.0, false, 0);
+    sim_man = new SimulationManager(world_path.string() + "world.yaml",
+                                    world_path.string(),
+                                    world_path.string() + "world_plugins.yaml",
+                                    true, 1000, 1 / 1000.0, false, 0);
     simulation_thread = std::thread(&ServiceManagerTest::SimulationThread,
                                     dynamic_cast<ServiceManagerTest*>(this));
   }
@@ -98,8 +100,7 @@ class ServiceManagerTest : public ::testing::Test {
  * Testing service for loading a model which should succeed
  */
 TEST_F(ServiceManagerTest, spawn_valid_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   robot_yaml = this_file_dir /
                fs::path("load_world_tests/simple_test_A/person.model.yaml");
@@ -140,8 +141,7 @@ TEST_F(ServiceManagerTest, spawn_valid_model) {
  * Testing service for loading a model which should fail
  */
 TEST_F(ServiceManagerTest, spawn_invalid_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   robot_yaml = this_file_dir / fs::path("random_path/turtlebot.model.yaml");
 
@@ -176,8 +176,7 @@ TEST_F(ServiceManagerTest, spawn_invalid_model) {
  * Testing service for moving a valid model
  */
 TEST_F(ServiceManagerTest, move_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   flatland_msgs::MoveModel srv;
   srv.request.name = "turtlebot1";
@@ -206,8 +205,7 @@ TEST_F(ServiceManagerTest, move_model) {
  * Testing service for moving a nonexistent model
  */
 TEST_F(ServiceManagerTest, move_nonexistent_model) {
-  world_yaml =
-      this_file_dir / fs::path("load_world_tests/simple_test_A/world.yaml");
+  world_path = this_file_dir / fs::path("load_world_tests/simple_test_A/");
 
   flatland_msgs::MoveModel srv;
   srv.request.name = "not_a_robot";
@@ -233,8 +231,8 @@ TEST_F(ServiceManagerTest, move_nonexistent_model) {
  * Testing service for deleting a model
  */
 TEST_F(ServiceManagerTest, delete_model) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_path =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
   flatland_msgs::DeleteModel srv;
   srv.request.name = "turtlebot1";
@@ -260,8 +258,8 @@ TEST_F(ServiceManagerTest, delete_model) {
  * Testing service for deleting a model that does not exist, should fail
  */
 TEST_F(ServiceManagerTest, delete_nonexistent_model) {
-  world_yaml = this_file_dir /
-               fs::path("plugin_manager_tests/load_dummy_test/world.yaml");
+  world_path =
+      this_file_dir / fs::path("plugin_manager_tests/load_dummy_test/");
 
   flatland_msgs::DeleteModel srv;
   srv.request.name = "random_model";


### PR DESCRIPTION
- use_local_map optional argument, if it is provided, then it will wait for map_changed, otherwise it would not
- Starts the world plugins separately from the map.yaml file. Starts the world_plugins (inventory_system etc) separately
- Update unit tests to reflect the change in the world_plugins.yaml file vs the map.world.yaml file