### PR TITLE
Occupied thresh is flipped

### DIFF
--- a/flatland_server/src/layer.cpp
+++ b/flatland_server/src/layer.cpp
@@ -237,7 +237,7 @@ void Layer::LoadFromBitmap(const cv::Mat &bitmap, double occupied_thresh,
 
   // thresholds the map, values between the occupied threshold and 1.0 are
   // considered to be occupied
-  cv::inRange(bitmap, occupied_thresh, 1.0, obstacle_map);
+  cv::inRange(bitmap, 1 - occupied_thresh, 1.0, obstacle_map);
 
   // pad the top and bottom of the map each with an empty row (255=white). This
   // helps to look at the transition from one row of pixel to another


### PR DESCRIPTION
In the occupancy map, 0 is white and 1 is black. On openCV, 0 is black and 1 is white. Thus 
- occupancy threshold to black is considered obstacles in the occupancy grid
- 0 - occ = obstacles in occupancy map
- (1 - occ) to 1 = obstacles in opencv